### PR TITLE
static supported function

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,8 @@ var exportee = module.exports = function (config) {
 
 	// static data
 	var _staticJSON = {};
+    // static function
+    var _staticFunc = {};
 	// read data sources
 	var fetchers = {};
 
@@ -39,6 +41,16 @@ var exportee = module.exports = function (config) {
 
 			// copy the staticJSON
 			var renderData = extend(contextParam, JSON.parse(JSON.stringify(_staticJSON)));
+
+            // inject the return value of staticFunc
+            Object.keys(_staticFunc).forEach(key => {
+                var result = _staticFunc[key](contextParam);
+                if (typeof(result) === 'object') {
+                    createInjector(key, renderData)(result);
+                }else{
+                    console.log(`WARNING: static ${key} is ignored, function of value must return object`);
+                }
+            });
 
 			var requestTree = {};
 
@@ -122,8 +134,8 @@ var exportee = module.exports = function (config) {
 			// static json, put it into result
 			// _staticJSON[key] = value;
 
-			// put the static data into result
-			createInjector(key, _staticJSON)(dataSource.value);
+			typeof(dataSource.value) === 'function' ? (_staticFunc[key] = dataSource.value) // put the static function
+                : createInjector(key, _staticJSON)(dataSource.value); // put the static data into result
 
 		} else {
 			throw new Error('must indicate a type for datasource');

--- a/test/serve.test.js
+++ b/test/serve.test.js
@@ -187,6 +187,24 @@ test('static data', async function () {
 				action: {
 					url: "what://ever"
 				}
+			},
+			'ret.func': {
+				type: "static",
+				value: function(req){
+					return {"hehe": 1}
+				}
+			},
+			'ret1': {
+				type: "static",
+				value: function(req){
+					return {"hehe": 1}
+				}
+			},
+			'retUndefine': {
+				type: "static",
+				value: function(req){
+					// return {"hehe": 1}
+				}
 			}
 		},
 		render: function (data) {
@@ -196,6 +214,10 @@ test('static data', async function () {
 	assert.equal(result.ret.json.hehe, 1);
 	assert(result.ret.request.testdata);
 	assert.equal(result['ret.json'], void 0);
+	assert.equal(result.ret.func.hehe, 1);
+	assert.equal(result['ret.func'], void 0);
+	assert.equal(result.ret1.hehe, 1);
+	assert.equal(result['retUndefine'], void 0);
 });
 test('invalid data source', async function () {
 	try {


### PR DESCRIPTION
static 中的value 支持function，如：
`        title: {
            type: "static",
            value: function(req) {
                // console.log(req)
                return { "food": "cabbage" }
            }
        }`


场景：
根据query等上下文 选择配置